### PR TITLE
Small fix to get the entire header name when use the -h option on the…

### DIFF
--- a/JmsProducer/src/main/java/name/wramner/jmstools/producer/JmsProducerConfiguration.java
+++ b/JmsProducer/src/main/java/name/wramner/jmstools/producer/JmsProducerConfiguration.java
@@ -157,7 +157,7 @@ public abstract class JmsProducerConfiguration extends JmsClientConfiguration {
         for (String headerKeyValuePair : _headers) {
             int pos = headerKeyValuePair.indexOf('=');
             if (pos != -1) {
-                int endIndexForKey = pos - 1;
+                int endIndexForKey = pos;
                 int startIndexForValue = pos + 1;
                 headerMap.put(headerKeyValuePair.substring(0, endIndexForKey),
                                 startIndexForValue < headerKeyValuePair.length()


### PR DESCRIPTION
… JmsProducer

Seems like String.indexOf is zero indexed whereas String.substring is not.
Without this fix the last character of the header name is omitted when using the -h option